### PR TITLE
Don't panic on 4-byte IPs

### DIFF
--- a/geoip.go
+++ b/geoip.go
@@ -11,12 +11,13 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"github.com/alecthomas/geoip/db"
 	"io"
 	"io/ioutil"
 	"net"
 	"sort"
 	"unsafe"
+
+	"github.com/alecthomas/geoip/db"
 )
 
 type ipRange struct {
@@ -83,7 +84,7 @@ func New() (*GeoIP, error) {
 
 // Find country of IP.
 func (g *GeoIP) Lookup(ip net.IP) *Country {
-	bip := []byte(ip)[12:]
+	bip := []byte(ip.To4())
 	i := sort.Search(len(g.ranges), func(i int) bool {
 		return bytes.Compare(g.ranges[i].start[:], bip) > 0
 	})

--- a/geoip_test.go
+++ b/geoip_test.go
@@ -8,6 +8,32 @@ import (
 	"testing"
 )
 
+func TestGeoIpLookup(t *testing.T) {
+	db, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		ip      net.IP
+		country Country
+	}{
+		{net.ParseIP("8.8.8.8"), Country{"US", "United States"}},
+		{net.ParseIP("8.8.8.8").To4(), Country{"US", "United States"}},
+		{net.ParseIP("8.8.8.8").To4()[:3], Country{}},
+		{net.ParseIP("8.8.8.8")[:15], Country{}},
+		{nil, Country{}},
+	}
+	for _, c := range cases {
+		var country Country
+		if ct := db.Lookup(c.ip); ct != nil {
+			country = *ct
+		}
+		if country != c.country {
+			t.Errorf("%s (%#v) expected %v, got %v", c.ip, c.ip, c.country, country)
+		}
+	}
+}
+
 func BenchmarkGeoIpLookup(t *testing.B) {
 	db, err := New()
 	if err != nil {


### PR DESCRIPTION
According to http://golang.org/pkg/net/#IP, 4-byte array is a valid representation of `net.IP`. This package currently panics when performing lookups of such IPs. This patch addresses the issue by converting every IP to 4-byte representation using a method from net package, rather than slicing it assuming 16-byte representation. This will also remove a panic for malformed IPs shorter than 12 bytes (Lookup will return nil).

Backed by a unit test.

(Reordering of imports is just a side effect of calling goimports.)